### PR TITLE
Sentence case links

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/feedback_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/feedback_form.jsp
@@ -53,8 +53,8 @@
       <div class="col-xs-12 col-sm-6 general-help">
         <h2 tabindex="0" aria-label="Get help">Get help</h2>
           <a href='/portal/p/campus-chat-connections'><i class="fa fa-comments-o"></i>Live chat</a>
-          <a href='http://helpdesk.doit.wisc.edu/page.php?id=1' target='_blank'><i class="fa fa-phone"></i>Call Us</a>
-          <a href='https://kb.wisc.edu/myuw/' target='_blank'><i class="fa fa-question"></i>How-to Info</a>
+          <a href='http://helpdesk.doit.wisc.edu/page.php?id=1' target='_blank'><i class="fa fa-phone"></i>Call us</a>
+          <a href='https://kb.wisc.edu/myuw/' target='_blank'><i class="fa fa-question"></i>How-to info</a>
       </div>
     </div>
   </div>

--- a/src/main/webapp/WEB-INF/jsp/feedback_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/feedback_form.jsp
@@ -51,10 +51,7 @@
         </form>
       </div>
       <div class="col-xs-12 col-sm-6 general-help">
-        <h2 tabindex="0" aria-label="Get help">Get help</h2>
-          <a href='/portal/p/campus-chat-connections'><i class="fa fa-comments-o"></i>Live chat</a>
-          <a href='http://helpdesk.doit.wisc.edu/page.php?id=1' target='_blank'><i class="fa fa-phone"></i>Call us</a>
-          <a href='https://kb.wisc.edu/myuw/' target='_blank'><i class="fa fa-question"></i>How-to info</a>
+        <jsp:directive.include file="/WEB-INF/jsp/include-righthand-links.jsp"/>
       </div>
     </div>
   </div>

--- a/src/main/webapp/WEB-INF/jsp/feedback_success.jsp
+++ b/src/main/webapp/WEB-INF/jsp/feedback_success.jsp
@@ -11,8 +11,8 @@
       <div class="col-xs-12 col-sm-6 general-help">
         <h2>Get help</h2>
           <a href='/portal/p/campus-chat-connections'><i class="fa fa-comments-o"></i>Live chat</a>
-          <a href='http://helpdesk.doit.wisc.edu/page.php?id=1' target='_blank'><i class="fa fa-phone"></i>Call Us</a>
-          <a href='https://kb.wisc.edu/myuw/' target='_blank'><i class="fa fa-question"></i>How-to Info</a>
+          <a href='http://helpdesk.doit.wisc.edu/page.php?id=1' target='_blank'><i class="fa fa-phone"></i>Call us</a>
+          <a href='https://kb.wisc.edu/myuw/' target='_blank'><i class="fa fa-question"></i>How-to info</a>
       </div>
     </div>
   </div>

--- a/src/main/webapp/WEB-INF/jsp/feedback_success.jsp
+++ b/src/main/webapp/WEB-INF/jsp/feedback_success.jsp
@@ -9,10 +9,7 @@
         </div>
       </div>
       <div class="col-xs-12 col-sm-6 general-help">
-        <h2>Get help</h2>
-          <a href='/portal/p/campus-chat-connections'><i class="fa fa-comments-o"></i>Live chat</a>
-          <a href='http://helpdesk.doit.wisc.edu/page.php?id=1' target='_blank'><i class="fa fa-phone"></i>Call us</a>
-          <a href='https://kb.wisc.edu/myuw/' target='_blank'><i class="fa fa-question"></i>How-to info</a>
+        <jsp:directive.include file="/WEB-INF/jsp/include-righthand-links.jsp"/>
       </div>
     </div>
   </div>

--- a/src/main/webapp/WEB-INF/jsp/include-righthand-links.jsp
+++ b/src/main/webapp/WEB-INF/jsp/include-righthand-links.jsp
@@ -1,0 +1,4 @@
+<h2>Get help</h2>
+<a href='/portal/p/campus-chat-connections'><i class="fa fa-comments-o"></i>Live chat</a>
+<a href='http://helpdesk.doit.wisc.edu/page.php?id=1' target='_blank'><i class="fa fa-phone"></i>Call us</a>
+<a href='https://kb.wisc.edu/myuw/' target='_blank'><i class="fa fa-question"></i>How-to info</a>


### PR DESCRIPTION
Tweak to consistently use sentence-case capitalization in the right-hand links.

Refactors those links into a single include JSP rather than duplicate content across the form and success JSPs.
