### PR TITLE
MUMUP-2558 Make Outgoing Feedback Email Configurable

### DIFF
--- a/src/main/java/edu/wisc/my/portlets/feedback/beans/Feedback.java
+++ b/src/main/java/edu/wisc/my/portlets/feedback/beans/Feedback.java
@@ -57,6 +57,7 @@ public class Feedback implements Serializable {
     private String hiddenPhoneNumber;
     private String hiddenEmailAddress;
     private String campus;
+    private String feedbackResponseEmail;
     private String subject;
     private String details;
     private String userAgent;
@@ -150,6 +151,8 @@ public class Feedback implements Serializable {
     public void setHiddenEmailAddress(final String emailAddress) {
         this.hiddenEmailAddress = emailAddress;
     }
+    
+    
     /**
      * @return Returns the name.
      */
@@ -278,4 +281,18 @@ public class Feedback implements Serializable {
     public void setReferrer(String referrer) {
         this.referrer = referrer;
     }
+    
+    /**
+     * @return the campus-specific email address. Set in portlet preferences.
+     */
+	public String getFeedbackResponseEmail() {
+		return feedbackResponseEmail;
+	}
+	
+	/**
+     * @param feedbackResponseEmail the email address to which feedback will be directed
+     */
+	public void setFeedbackResponseEmail(String feedbackResponseEmail) {
+		this.feedbackResponseEmail = feedbackResponseEmail;
+	}
 }

--- a/src/main/java/edu/wisc/my/portlets/feedback/dao/ClarifyFeedbackMessageFormatterImpl.java
+++ b/src/main/java/edu/wisc/my/portlets/feedback/dao/ClarifyFeedbackMessageFormatterImpl.java
@@ -77,7 +77,13 @@ public class ClarifyFeedbackMessageFormatterImpl implements
     public SimpleMailMessage format(Feedback feedback) {
         SimpleMailMessage message = new SimpleMailMessage();
 
-        message.setTo(targetEmail);
+        if(feedback.getFeedbackResponseEmail() != null){
+        	message.setTo(feedback.getFeedbackResponseEmail());
+        }else{
+        	message.setTo(targetEmail);
+        }
+        
+        
         message.setFrom(fromAddress);
 
         message.setSubject("CALL_CREATE"+" "+feedback.getSubject());

--- a/src/main/java/edu/wisc/my/portlets/feedback/web/FeedbackFormController.java
+++ b/src/main/java/edu/wisc/my/portlets/feedback/web/FeedbackFormController.java
@@ -84,9 +84,11 @@ public class FeedbackFormController extends SimpleFormController {
     	final PortletPreferences preferences = request.getPreferences();
     	
     	if(preferences !=null){
-    		request.setAttribute("chatLink",(preferences.getValue("chatLink", null)));
-    		request.setAttribute("callLink",(preferences.getValue("callLink", null)));
+    		request.setAttribute("chatLink",(preferences.getValue("chatLink", "null")));
+    		request.setAttribute("callLink",(preferences.getValue("callLink", "null")));
     		request.setAttribute("howToLink",(preferences.getValue("howToLink", null)));
+            feedback.setFeedbackResponseEmail(preferences.getValue("feedbackResponseEmail", null));
+     
     	}else{
     		request.setAttribute("chatLink",null);
     		request.setAttribute("callLink",null);
@@ -112,6 +114,8 @@ public class FeedbackFormController extends SimpleFormController {
         final String telephoneNumber = userInfo.get("telephoneNumber");
         feedback.setPhoneNumber(telephoneNumber);
         feedback.setHiddenPhoneNumber(telephoneNumber);
+        
+        
         
         
         if(request.isUserInRole("ROLE_BETA_PROFILE")){

--- a/src/main/java/edu/wisc/my/portlets/feedback/web/FeedbackFormController.java
+++ b/src/main/java/edu/wisc/my/portlets/feedback/web/FeedbackFormController.java
@@ -86,13 +86,13 @@ public class FeedbackFormController extends SimpleFormController {
     	if(preferences !=null){
     		request.setAttribute("chatLink",(preferences.getValue("chatLink", "null")));
     		request.setAttribute("callLink",(preferences.getValue("callLink", "null")));
-    		request.setAttribute("howToLink",(preferences.getValue("howToLink", null)));
-            feedback.setFeedbackResponseEmail(preferences.getValue("feedbackResponseEmail", null));
+    		request.setAttribute("howToLink",(preferences.getValue("howToLink", "null")));
+            feedback.setFeedbackResponseEmail(preferences.getValue("feedbackResponseEmail", "null"));
      
     	}else{
-    		request.setAttribute("chatLink",null);
-    		request.setAttribute("callLink",null);
-    		request.setAttribute("howToLink",null);
+    		request.setAttribute("chatLink","null");
+    		request.setAttribute("callLink","null");
+    		request.setAttribute("howToLink","null");
     	}
     	
     	


### PR DESCRIPTION
Also fixed a preference glitch. A missing preference will now pass the string "null" as a value, in order to make client side interpretation less ambiguous. 
